### PR TITLE
Update v.sh

### DIFF
--- a/CKA/pod-log/step1/v.sh
+++ b/CKA/pod-log/step1/v.sh
@@ -28,12 +28,14 @@ fi
 
 # Check the command and args
 EXPECTED_COMMAND="/bin/sh"
-EXPECTED_ARGS="tail -f /config/log.txt"
+EXPECTED_ARGS0="-c"
+EXPECTED_ARGS1="tail -f /config/log.txt"
 
 CURRENT_COMMAND=$(kubectl get pod "$POD_NAME" -o jsonpath="{.spec.containers[?(@.name=='$CONTAINER_NAME')].command[0]}")
-CURRENT_ARGS=$(kubectl get pod "$POD_NAME" -o jsonpath="{.spec.containers[?(@.name=='$CONTAINER_NAME')].args[0]}")
+CURRENT_ARGS0=$(kubectl get pod "$POD_NAME" -o jsonpath="{.spec.containers[?(@.name=='$CONTAINER_NAME')].args[0]}")
+CURRENT_ARGS1=$(kubectl get pod "$POD_NAME" -o jsonpath="{.spec.containers[?(@.name=='$CONTAINER_NAME')].args[1]}")
 
-if [ "$CURRENT_COMMAND" = "$EXPECTED_COMMAND" ] && [ "$CURRENT_ARGS" = "$EXPECTED_ARGS" ]; then
+if [ "$CURRENT_COMMAND" = "$EXPECTED_COMMAND" ] && [ "$CURRENT_ARGS0" = "$EXPECTED_ARGS0" ] && [ "$CURRENT_ARGS1" = "$EXPECTED_ARGS1" ]; then
   echo "Command and args are correctly set."
 else
   echo "Error: Command and args are not correctly set."


### PR DESCRIPTION
Currently, the validation logic fails because it only checks the first argument (args[0]) of the container. However, when using /bin/sh as the command in a Kubernetes pod, the first argument must be -c, otherwise the shell will not interpret the following string as a command to execute. This is a requirement of how sh works.